### PR TITLE
Added 'get-body' function that casts Exchange message body to a given…

### DIFF
--- a/src/camelarius/core.clj
+++ b/src/camelarius/core.clj
@@ -91,9 +91,11 @@
   (set-in-body ex body))
 
 (defn get-body
-  "get the message body as a string"
-  [ex]
-  (.. ex (getIn) (getBody)))
+  "Get the message body"
+  ([ex]
+    (.. ex (getIn) (getBody)))
+  ([ex clazz]
+    (.. ex (getIn) (getBody clazz))))
 
 (defn set-header
   "Useful for setting state inside processors"

--- a/test/camelarius/test/eip/messaging_systems.clj
+++ b/test/camelarius/test/eip/messaging_systems.clj
@@ -39,7 +39,7 @@
       ((make-producer context) "direct:source" "msg")
       (let [mock-dest (make-endpoint context "mock:dest")]
         (received-counter mock-dest) => 1
-        (get-body (first (received-exchanges mock-dest))) => "abc"))))
+        (get-body (first (received-exchanges mock-dest)) String) => "abc"))))
 
 
 (facts "Message Router EIP"


### PR DESCRIPTION
Added another version of the `get-body` function that casts exchange message body to a given Java class. I needed it while I was writing a [camel route that processed tweets](https://github.com/erasmas/twitter-elasticsearch-writer/blob/master/src/twitter_elasticsearch_writer/camel.clj#L5).
