### PR TITLE
fix exchange-pattern in-out due to illegal argument exception

### DIFF
--- a/src/camelarius/core.clj
+++ b/src/camelarius/core.clj
@@ -58,7 +58,7 @@
                       :or {exchange-pattern in-only headers {}}}]
       (if (= in-only exchange-pattern)
         (.sendBodyAndHeaders producer dest body (zipmap (map name (keys headers)) (vals headers)))
-        (.requestBody producer dest body (.class Object))))))
+        (.requestBody producer dest body)))))
 
 (defn make-endpoint [context url]
   (.getEndpoint context url))

--- a/test/camelarius/test/core.clj
+++ b/test/camelarius/test/core.clj
@@ -16,3 +16,16 @@
     (produce "direct:test" "foo")
     (fact "produce and route"
       @counter => 1)))
+
+(facts "Camel sanity checks for in-out exchange"
+
+  (let [context (make-context)
+        produce (make-producer context)]
+    (defroute context
+      :err-handler (default-error-handler)
+      (from "direct:test-out")
+      (process (processor (let [counter (get-body ex)]
+                            (set-out-body ex (inc counter))))))
+    (let [result (produce "direct:test-out" 1 :exchange-pattern in-out)]
+      (fact "produce in-out and route"
+            result => 2))))


### PR DESCRIPTION
Calling a producer with exchange-pattern = in-out throws a IllegalArgumentException because Object class does not have a class field. It is actually unnecessary to specify the type as Object when calling requestBody within a producer.

Exception in thread "main" java.lang.IllegalArgumentException: No matching field found: class for class java.lang.Class