### PR TITLE
in-out exchange now sends headers

### DIFF
--- a/src/camelarius/core.clj
+++ b/src/camelarius/core.clj
@@ -56,9 +56,10 @@
     (.start producer)
     (fn [dest body & {:keys [exchange-pattern headers]
                       :or {exchange-pattern in-only headers {}}}]
-      (if (= in-only exchange-pattern)
-        (.sendBodyAndHeaders producer dest body (zipmap (map name (keys headers)) (vals headers)))
-        (.requestBody producer dest body)))))
+      (let [headers (zipmap (map name (keys headers)) (vals headers))]
+        (if (= in-only exchange-pattern)
+          (.sendBodyAndHeaders producer dest body headers)
+          (.requestBodyAndHeaders producer dest body headers))))))
 
 (defn make-endpoint [context url]
   (.getEndpoint context url))


### PR DESCRIPTION
I ran into an issue when using in-out pattern not being unable to send headers using camelarius, this should fix that problem.